### PR TITLE
Convert job parameter values to str before concatenating

### DIFF
--- a/tools/bam_to_scidx_output_stats.xml
+++ b/tools/bam_to_scidx_output_stats.xml
@@ -23,7 +23,7 @@
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/bedtools_intersectbed_output_stats.xml
+++ b/tools/bedtools_intersectbed_output_stats.xml
@@ -35,7 +35,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if $workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/bwa_mem_output_stats_single.xml
+++ b/tools/bwa_mem_output_stats_single.xml
@@ -24,7 +24,7 @@
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/chexmix_output_stats.xml
+++ b/tools/chexmix_output_stats.xml
@@ -22,8 +22,8 @@
             #set tool_id = $job.tool_id
             #set tool_parameters = ""                                                                                                        
             #for $p in $job.parameters:
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.name                                                                
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value                                                               
+                #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions                                                                                               

--- a/tools/cwpair2_output_stats.xml
+++ b/tools/cwpair2_output_stats.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/extract_genomic_dna_output_stats.xml
+++ b/tools/extract_genomic_dna_output_stats.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/extract_genomic_dna_output_stats2.xml
+++ b/tools/extract_genomic_dna_output_stats2.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/extract_genomic_dna_output_stats3.xml
+++ b/tools/extract_genomic_dna_output_stats3.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/fasta_nucleotide_color_plot_output_stats.xml
+++ b/tools/fasta_nucleotide_color_plot_output_stats.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/fastqc_output_stats.xml
+++ b/tools/fastqc_output_stats.xml
@@ -26,7 +26,7 @@
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/fastqc_output_stats2.xml
+++ b/tools/fastqc_output_stats2.xml
@@ -26,7 +26,7 @@
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/galaxy_post_pegr.xml
+++ b/tools/galaxy_post_pegr.xml
@@ -26,7 +26,7 @@ The tool is compatible with most of the Galaxy tools and will send meta data inf
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/genetrack_output_stats.xml
+++ b/tools/genetrack_output_stats.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/mark_duplicates_bam_output_stats.xml
+++ b/tools/mark_duplicates_bam_output_stats.xml
@@ -24,7 +24,7 @@
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/meme_fimo_output_stats.xml
+++ b/tools/meme_fimo_output_stats.xml
@@ -39,7 +39,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/meme_meme_output_stats.xml
+++ b/tools/meme_meme_output_stats.xml
@@ -39,7 +39,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/pe_histogram_output_stats.xml
+++ b/tools/pe_histogram_output_stats.xml
@@ -26,7 +26,7 @@
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/repeatmasker_wrapper_output_stats.xml
+++ b/tools/repeatmasker_wrapper_output_stats.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/repeatmasker_wrapper_output_stats2.xml
+++ b/tools/repeatmasker_wrapper_output_stats2.xml
@@ -34,7 +34,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #if workflow_step is None:
                     #set pjaas = $job.post_job_actions

--- a/tools/samtool_filter2_output_stats.xml
+++ b/tools/samtool_filter2_output_stats.xml
@@ -23,7 +23,7 @@
             #set tool_parameters = ""
             #for $p in $job.parameters:
                 #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
             #end for
             #set workflow_step = None
             #set pjaas = $job.post_job_actions

--- a/tools/tag_pileup_frequency_output_stats.xml
+++ b/tools/tag_pileup_frequency_output_stats.xml
@@ -33,7 +33,7 @@
                 #set tool_parameters = ""
                 #for $p in $job.parameters:
                     #set tool_parameters = $tool_parameters + "__SeP__" + $p.name
-                    #set tool_parameters = $tool_parameters + "__SeP__" + $p.value
+                    #set tool_parameters = $tool_parameters + "__SeP__" + str($p.value)
                 #end for
                 #set pjaas = $job.post_job_actions
                 #for pjaa in $pjaas:


### PR DESCRIPTION
Job parameter values should be converted to strings before concatenating to avoid python errors.